### PR TITLE
feat: pose-based photo verification and explore crash fix

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -41,6 +41,10 @@ import PrivacyPolicy from "./pages/PrivacyPolicy";
 import {updateUserProfile} from "@/hooks/useUser.ts";
 import { User } from "@/types/user.ts";
 import DeleteAccount from "./pages/DeleteAccount";
+import { AdminRoute } from "./pages/AdminRoute";
+import AdminLayout from "./pages/admin/AdminLayout";
+import VerificationQueue from "./pages/admin/VerificationQueue";
+import VerificationChallenges from "./pages/admin/VerificationChallenges";
 
 const queryClient = new QueryClient();
 
@@ -229,6 +233,10 @@ function App() {
             <Route path="/contact" element={<Contact />} />
             <Route path="/privacy-policy" element={<PrivacyPolicy />} />
             <Route path="/delete-account" element={<DeleteAccount />} />
+            <Route path="/admin" element={<AdminRoute><AdminLayout /></AdminRoute>}>
+              <Route path="verifications" element={<VerificationQueue />} />
+              <Route path="challenges" element={<VerificationChallenges />} />
+            </Route>
           </Routes>
           <ToastContainer />
         </AnimatePresence>

--- a/src/components/dashboard/FaceVerificationModal.tsx
+++ b/src/components/dashboard/FaceVerificationModal.tsx
@@ -1,10 +1,12 @@
-import {FC, useRef, useState} from 'react'
+import {FC, useEffect, useRef, useState} from 'react'
 import {AnimatePresence, motion} from "framer-motion";
 import {captureImage, startCamera} from "@/utils/cameraUtils.ts";
 import toast from "react-hot-toast";
 import {doc, Timestamp, updateDoc} from "firebase/firestore";
 import {db} from "@/firebase";
 import {useAuthStore} from "@/store/UserId.tsx";
+import {getRandomChallenge} from "@/hooks/useVerificationChallenge.ts";
+import {VerificationChallenge} from "@/types/verification.ts";
 
 interface FaceVerificationModalProps {
 		show: boolean
@@ -24,7 +26,16 @@ export const FaceVerificationModal: FC<FaceVerificationModalProps> = ({show, onC
 		const [capturedImage, setCapturedImage] = useState<string | null>(null);
 		const [cameraHasStarted, setCameraHasStarted] = useState<boolean>(false);
 		const [pictureHasBeenTaken, setPictureHasBeenTaken] = useState<boolean>(false);
+		const [challenge, setChallenge] = useState<VerificationChallenge | null>(null);
 		const { auth } = useAuthStore();
+
+		useEffect(() => {
+				if (show) {
+						getRandomChallenge()
+								.then(setChallenge)
+								.catch((e) => console.error("Error fetching verification challenge:", e));
+				}
+		}, [show]);
 
 		const updateFaceVerification = async () => {
 				if (!auth?.uid) {
@@ -41,7 +52,10 @@ export const FaceVerificationModal: FC<FaceVerificationModalProps> = ({show, onC
 										face_verification:{
 												retake_photo: false,
 												photo: capturedImage,
-												updated_at: Timestamp.now()
+												updated_at: Timestamp.now(),
+												challenge_id: challenge?.id ?? null,
+												challenge_image_url: challenge?.image_url ?? null,
+												status: 'pending_review',
 										}
 								});
 						}
@@ -67,6 +81,12 @@ export const FaceVerificationModal: FC<FaceVerificationModalProps> = ({show, onC
 					<motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }} transition={{ duration: 0.3 }} className="bg-white text opacity-100 z-[9999] py-[2rem] px-[4rem] space-y-[3rem] rounded-[2rem]">
 							<div>
 									<h1 className='text-3xl font-bold flex justify-center mb-[2rem]'>Take A Selfie</h1>
+									{challenge && (
+											<div className={`grid gap-y-2 mb-4`}>
+													<p className={`text-[1.4rem] font-bold`}>Match this pose: {challenge.label}</p>
+													<img className={`w-[120px] h-[90px] object-cover rounded-[10px]`} src={challenge.image_url} alt="Verification pose to match" />
+											</div>
+									)}
 									<div className={`w-[300px] h-[225px] bg-center bg-no-repeat bg-cover rounded-[15px] bg-opacity-20 bg-[#8A8A8E] relative overflow-hidden mb-8`}>
 											<video className={`size-full absolute z-30 video-flip ${capturedImage ? "hidden" : "block"}`} ref={videoRef} autoPlay></video>
 											<canvas className={`size-full absolute z-20`} ref={canvasRef} style={{display: 'none'}}></canvas>

--- a/src/components/onboarding/TakeASelfie.tsx
+++ b/src/components/onboarding/TakeASelfie.tsx
@@ -16,6 +16,8 @@ import Modal from "../ui/Modal";
 import Lottie from "lottie-react";
 import Cat from "../../Cat.json";
 import {captureImage, startCamera} from "@/utils/cameraUtils.ts";
+import {getRandomChallenge} from "@/hooks/useVerificationChallenge.ts";
+import {VerificationChallenge} from "@/types/verification.ts";
 
 export const TakeASelfie: React.FC<OnboardingProps> = ({ goBack }) => {
 		const [openModal, setOpenModal] = useState(false);
@@ -30,12 +32,19 @@ export const TakeASelfie: React.FC<OnboardingProps> = ({ goBack }) => {
 		const [capturedImage, setCapturedImage] = useState<string | null>(null);
 		const [cameraHasStarted, setCameraHasStarted] = useState<boolean>(false);
 		const [pictureHasBeenTaken, setPictureHasBeenTaken] = useState<boolean>(false);
+		const [challenge, setChallenge] = useState<VerificationChallenge | null>(null);
 
 		useEffect(() => {
 				if (auth?.has_completed_onboarding) {
 						navigate('/dashboard/explore');
 				}
 		}, [auth?.has_completed_onboarding]);
+
+		useEffect(() => {
+				getRandomChallenge()
+						.then(setChallenge)
+						.catch((e) => console.error("Error fetching verification challenge:", e));
+		}, []);
 
 		const handleFaceVerificationSkip = () => {
 				setOpenModal(true);
@@ -64,7 +73,10 @@ export const TakeASelfie: React.FC<OnboardingProps> = ({ goBack }) => {
 										face_verification:{
 												retake_photo: false,
 												photo: capturedImage,
-												updated_at: Timestamp.now()
+												updated_at: Timestamp.now(),
+												challenge_id: challenge?.id ?? null,
+												challenge_image_url: challenge?.image_url ?? null,
+												status: 'pending_review',
 										}
 								});
 						}
@@ -105,6 +117,12 @@ export const TakeASelfie: React.FC<OnboardingProps> = ({ goBack }) => {
 										</div>
 
 										<div className={`grid gap-y-6`}>
+												{challenge && (
+														<div className={`grid gap-y-2`}>
+																<p className={`text-[12px] font-bold`}>Match this pose: {challenge.label}</p>
+																<img className={`w-[120px] h-[90px] object-cover rounded-[10px]`} src={challenge.image_url} alt="Verification pose to match" />
+														</div>
+												)}
 												<div className={`w-[300px] h-[225px] bg-center bg-no-repeat bg-cover rounded-[15px] bg-opacity-20 bg-[#8A8A8E] relative overflow-hidden`}>
 														<video className={`size-full absolute z-30 video-flip ${capturedImage ? "hidden" : "block"}`} ref={videoRef} autoPlay></video>
 														<canvas className={`size-full absolute z-20`} ref={canvasRef} style={{ display: 'none' }}></canvas>

--- a/src/hooks/useProfileFetcher.tsx
+++ b/src/hooks/useProfileFetcher.tsx
@@ -147,7 +147,8 @@ function useProfileFetcher() {
 					// where("meet","in", [2, user.meet === 0 ? 1 : 0])
 				);
 			} else {
-				throw new Error("Invalid meet value provided.");
+				console.error("Invalid meet value provided.", user.meet);
+				q = q_base;
 			}
 		} else {
 			q = q_base;

--- a/src/hooks/useUser.ts
+++ b/src/hooks/useUser.ts
@@ -51,15 +51,24 @@ const updateAdvancedSearchPreferences = async (
   });
 }
 
-const getAdvancedSearchPreferences = async (uid: string) => {
+const defaultAdvancedSearchPreferences: AdvancedSearchPreferences = {
+  gender: '',
+  age_range: { min: 18, max: 100 },
+  country: '',
+  relationship_preference: null,
+  religion: null,
+};
+
+const getAdvancedSearchPreferences = async (uid: string): Promise<AdvancedSearchPreferences> => {
   const docRef = doc(db, "advancedSearchPreferences", uid as string);
   const docSnap = await getDoc(docRef);
 
   if (docSnap.exists()) {
-    return docSnap.data() as AdvancedSearchPreferences;
-  } else {
-    console.log("No such document!");
+    return { ...defaultAdvancedSearchPreferences, ...docSnap.data() } as AdvancedSearchPreferences;
   }
+
+  console.log("No such document!");
+  return defaultAdvancedSearchPreferences;
 }
 
 export { getUserProfile, updateUserProfile, updateAdvancedSearchPreferences, getAdvancedSearchPreferences };

--- a/src/hooks/useVerificationChallenge.ts
+++ b/src/hooks/useVerificationChallenge.ts
@@ -1,0 +1,11 @@
+import { collection, getDocs, query, where } from "firebase/firestore";
+import { db } from "@/firebase";
+import { VerificationChallenge } from "@/types/verification";
+
+export async function getRandomChallenge(): Promise<VerificationChallenge | null> {
+  const snap = await getDocs(query(collection(db, "verification_challenges"), where("is_active", "==", true)));
+  if (snap.empty) return null;
+
+  const pick = snap.docs[Math.floor(Math.random() * snap.docs.length)];
+  return { id: pick.id, ...pick.data() } as VerificationChallenge;
+}

--- a/src/pages/AdminRoute.tsx
+++ b/src/pages/AdminRoute.tsx
@@ -1,0 +1,32 @@
+import { useAuthStore } from "@/store/UserId";
+import React, { useEffect, useState } from "react";
+import { Navigate } from "react-router-dom";
+import { doc, getDoc } from "firebase/firestore";
+import { db } from "@/firebase";
+
+interface AdminRouteProps {
+  children: React.ReactNode;
+}
+
+export const AdminRoute: React.FC<AdminRouteProps> = ({ children }) => {
+  const { auth, user } = useAuthStore();
+  const [isAdmin, setIsAdmin] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    if (!auth?.uid) {
+      setIsAdmin(false);
+      return;
+    }
+
+    getDoc(doc(db, "admins", auth.uid))
+      .then((snap) => setIsAdmin(snap.exists()))
+      .catch((err) => {
+        console.error("Error checking admin status:", err);
+        setIsAdmin(false);
+      });
+  }, [auth?.uid]);
+
+  if (!auth?.uid || !user) return <Navigate to="/auth" />;
+  if (isAdmin === null) return <p>Loading...</p>;
+  return isAdmin ? children : <Navigate to="/dashboard/explore" />;
+};

--- a/src/pages/PrivacyPolicy.tsx
+++ b/src/pages/PrivacyPolicy.tsx
@@ -48,6 +48,7 @@ const PrivacyPolicy: React.FC = () => {
                                 <li>Send marketing communications (with your consent).</li>
                                 <li>Personalize user experiences and advertisements.</li>
                                 <li>Ensure user safety and enforce our terms.</li>
+                                <li>Verify your identity, including reviewing selfie photos submitted for verification against a reference pose to confirm you are a real person. These photos are reviewed by Whossy staff.</li>
                                 <li>Comply with legal obligations and prevent fraud.</li>
                             </ol>
                         </div>

--- a/src/pages/admin/AdminLayout.tsx
+++ b/src/pages/admin/AdminLayout.tsx
@@ -1,0 +1,23 @@
+import { NavLink, Outlet } from "react-router-dom";
+
+const AdminLayout = () => {
+  const linkClass = ({ isActive }: { isActive: boolean }) =>
+    `px-4 py-2 rounded-md text-[1.4rem] font-medium ${isActive ? "bg-black text-white" : "text-black hover:bg-[#F6F6F6]"}`;
+
+  return (
+    <div className="min-h-screen bg-white">
+      <header className="flex items-center justify-between px-8 py-4 border-b border-[#F6F6F6]">
+        <h1 className="text-[2rem] font-bold">Whossy Admin</h1>
+        <nav className="flex gap-x-2">
+          <NavLink to="/admin/verifications" className={linkClass}>Verification Queue</NavLink>
+          <NavLink to="/admin/challenges" className={linkClass}>Challenges</NavLink>
+        </nav>
+      </header>
+      <main className="p-8">
+        <Outlet />
+      </main>
+    </div>
+  );
+};
+
+export default AdminLayout;

--- a/src/pages/admin/VerificationChallenges.tsx
+++ b/src/pages/admin/VerificationChallenges.tsx
@@ -1,0 +1,105 @@
+import { FormEvent, useEffect, useRef, useState } from "react";
+import { addDoc, collection, doc, onSnapshot, serverTimestamp, updateDoc } from "firebase/firestore";
+import { db } from "@/firebase";
+import { VerificationChallenge } from "@/types/verification";
+import upload from "@/hooks/upload";
+import toast from "react-hot-toast";
+
+type ChallengeDoc = VerificationChallenge & { id: string };
+
+const VerificationChallenges = () => {
+  const [challenges, setChallenges] = useState<ChallengeDoc[]>([]);
+  const [label, setLabel] = useState("");
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  useEffect(() => {
+    const unsubscribe = onSnapshot(
+      collection(db, "verification_challenges"),
+      (snap) => setChallenges(snap.docs.map((d) => ({ id: d.id, ...d.data() } as ChallengeDoc))),
+      (err) => console.error("Error fetching challenges:", err)
+    );
+
+    return () => unsubscribe();
+  }, []);
+
+  const toggleActive = async (challengeId: string, isActive: boolean) => {
+    try {
+      await updateDoc(doc(db, "verification_challenges", challengeId), { is_active: !isActive });
+    } catch (err) {
+      console.error("Error toggling challenge:", err);
+      toast.error("Failed to update challenge");
+    }
+  };
+
+  const addChallenge = async (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+
+    const file = fileInputRef.current?.files?.[0];
+    if (!file || !label.trim()) {
+      toast.error("Please provide an image and a label");
+      return;
+    }
+
+    setSubmitting(true);
+    try {
+      const image_url = await upload(file, "verification_challenges");
+      await addDoc(collection(db, "verification_challenges"), {
+        image_url,
+        label: label.trim(),
+        is_active: true,
+        created_at: serverTimestamp(),
+      });
+      setLabel("");
+      if (fileInputRef.current) fileInputRef.current.value = "";
+      toast.success("Challenge added");
+    } catch (err) {
+      console.error("Error adding challenge:", err);
+      toast.error("Failed to add challenge");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="grid gap-y-8">
+      <form onSubmit={addChallenge} className="grid gap-y-4 max-w-[400px]">
+        <p className="text-[1.6rem] font-bold">Add a new challenge pose</p>
+        <input ref={fileInputRef} type="file" accept="image/*" className="text-[1.4rem]" />
+        <input
+          type="text"
+          placeholder="Label, e.g. Smile and look left"
+          value={label}
+          onChange={(e) => setLabel(e.target.value)}
+          className="border border-[#F6F6F6] rounded-lg px-4 py-2 text-[1.4rem]"
+        />
+        <button
+          type="submit"
+          disabled={submitting}
+          className="bg-gradient-to-br from-orange-400 hover:opacity-70 to-red text-white py-[1rem] px-[2rem] text-[1.4rem] font-bold rounded-lg transition-all duration-300 cursor-pointer disabled:opacity-50">
+          {submitting ? "Adding..." : "Add challenge"}
+        </button>
+      </form>
+
+      <div className="grid gap-y-4">
+        <p className="text-[1.6rem] font-bold">Existing challenges</p>
+        {challenges.length === 0 && <p className="text-[1.4rem] text-[#8A8A8E]">No challenges yet.</p>}
+        <div className="grid gap-y-4">
+          {challenges.map((challenge) => (
+            <div key={challenge.id} className="flex items-center gap-x-4 border border-[#F6F6F6] rounded-[10px] p-4">
+              <img className="w-[100px] h-[75px] object-cover rounded-[10px]" src={challenge.image_url} alt={challenge.label} />
+              <p className="text-[1.4rem] font-bold flex-1">{challenge.label}</p>
+              <button
+                className={`py-[0.8rem] px-[1.6rem] text-[1.2rem] font-bold rounded-lg transition-all duration-300 cursor-pointer ${challenge.is_active ? "bg-[#F6F6F6] hover:bg-[#ececec]" : "bg-gradient-to-br from-orange-400 hover:opacity-70 to-red text-white"}`}
+                onClick={() => toggleActive(challenge.id, challenge.is_active)}>
+                {challenge.is_active ? "Deactivate" : "Activate"}
+              </button>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default VerificationChallenges;

--- a/src/pages/admin/VerificationQueue.tsx
+++ b/src/pages/admin/VerificationQueue.tsx
@@ -1,0 +1,109 @@
+import { useEffect, useState } from "react";
+import { collection, doc, getDocs, onSnapshot, query, serverTimestamp, updateDoc, where } from "firebase/firestore";
+import { db } from "@/firebase";
+import { useAuthStore } from "@/store/UserId";
+import { User } from "@/types/user";
+import { VerificationChallenge } from "@/types/verification";
+import toast from "react-hot-toast";
+
+type PendingUser = User & { uid: string };
+
+const VerificationQueue = () => {
+  const { auth } = useAuthStore();
+  const [pendingUsers, setPendingUsers] = useState<PendingUser[]>([]);
+  const [challengeLabels, setChallengeLabels] = useState<Record<string, string>>({});
+
+  useEffect(() => {
+    getDocs(collection(db, "verification_challenges")).then((snap) => {
+      const labels: Record<string, string> = {};
+      snap.docs.forEach((d) => {
+        const data = d.data() as VerificationChallenge;
+        labels[d.id] = data.label;
+      });
+      setChallengeLabels(labels);
+    }).catch((err) => console.error("Error fetching challenges:", err));
+  }, []);
+
+  useEffect(() => {
+    const unsubscribe = onSnapshot(
+      query(collection(db, "users"), where("face_verification.status", "==", "pending_review")),
+      (snap) => {
+        setPendingUsers(snap.docs.map((d) => ({ uid: d.id, ...d.data() } as PendingUser)));
+      },
+      (err) => console.error("Error fetching pending verifications:", err)
+    );
+
+    return () => unsubscribe();
+  }, []);
+
+  const reviewUser = async (uid: string, status: 'approved' | 'rejected') => {
+    if (!auth?.uid) return;
+
+    try {
+      await updateDoc(doc(db, "users", uid), {
+        'face_verification.status': status,
+        'face_verification.retake_photo': status === 'rejected',
+        'face_verification.reviewed_by': auth.uid,
+        'face_verification.reviewed_at': serverTimestamp(),
+      });
+      toast.success(status === 'approved' ? "User approved" : "User rejected");
+    } catch (err) {
+      console.error("Error reviewing user:", err);
+      toast.error("Failed to update verification status");
+    }
+  };
+
+  if (pendingUsers.length === 0) {
+    return <p className="text-[1.4rem] text-[#8A8A8E]">No pending verifications.</p>;
+  }
+
+  return (
+    <div className="grid gap-y-6">
+      {pendingUsers.map((user) => {
+        const challengeId = user.face_verification?.challenge_id;
+        const challengeLabel = challengeId ? challengeLabels[challengeId] : undefined;
+
+        return (
+          <div key={user.uid} className="border border-[#F6F6F6] rounded-[10px] p-4 grid gap-y-4">
+            <p className="text-[1.4rem] font-bold">{user.first_name} {user.last_name} <span className="text-[#8A8A8E] font-normal">({user.uid})</span></p>
+
+            <div className="flex gap-x-6 flex-wrap">
+              <div className="grid gap-y-2">
+                <p className="text-[1.2rem] font-bold">User was asked to: {challengeLabel ?? "Unknown pose"}</p>
+                {user.face_verification?.challenge_image_url ? (
+                  <img className="w-[160px] h-[120px] object-cover rounded-[10px]" src={user.face_verification.challenge_image_url} alt="Challenge pose" />
+                ) : (
+                  <div className="w-[160px] h-[120px] rounded-[10px] bg-[#F6F6F6] flex items-center justify-center text-[1.2rem] text-[#8A8A8E]">No challenge</div>
+                )}
+              </div>
+
+              <div className="grid gap-y-2">
+                <p className="text-[1.2rem] font-bold">Submitted selfie</p>
+                {user.face_verification?.photo ? (
+                  <img className="w-[160px] h-[120px] object-cover rounded-[10px]" src={user.face_verification.photo} alt="Submitted selfie" />
+                ) : (
+                  <div className="w-[160px] h-[120px] rounded-[10px] bg-[#F6F6F6] flex items-center justify-center text-[1.2rem] text-[#8A8A8E]">No photo</div>
+                )}
+              </div>
+            </div>
+
+            <div className="flex gap-x-4">
+              <button
+                className="bg-[#F6F6F6] py-[1rem] px-[2rem] text-[1.4rem] font-bold rounded-lg hover:bg-[#ececec] transition-all duration-300 cursor-pointer"
+                onClick={() => reviewUser(user.uid, 'rejected')}>
+                Reject
+              </button>
+              <button
+                className="bg-gradient-to-br from-orange-400 hover:opacity-70 to-red text-white py-[1rem] px-[2rem] text-[1.4rem] font-bold rounded-lg transition-all duration-300 cursor-pointer"
+                onClick={() => reviewUser(user.uid, 'approved')}>
+                Approve
+              </button>
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+};
+
+export default VerificationQueue;

--- a/src/pages/dashboard/Explore.tsx
+++ b/src/pages/dashboard/Explore.tsx
@@ -129,11 +129,11 @@ const Explore = () => {
     };
 
     const settingsData: SettingsDataItem[] = [
-        { label: 'Gender', value: advancedSearchPreferences.gender || 'Choose', onClick: () => setAdvancedSearchModalShowing('gender') },
-        { label: 'Age', value: `${advancedSearchPreferences.age_range?.min} - ${advancedSearchPreferences.age_range?.max} years old` || 'Choose', onClick: () => setAdvancedSearchModalShowing('age-range') },
-        { label: 'Country of Residence', value: advancedSearchPreferences.country || 'Choose', onClick: () => setAdvancedSearchModalShowing('country') },
-        { label: 'Relationship Preference', value: advancedSearchPreferences.relationship_preference !== null ? preference[advancedSearchPreferences.relationship_preference as number] : 'Choose', onClick: () => setAdvancedSearchModalShowing('relationship_preference') },
-        { label: 'Religion', value: advancedSearchPreferences.religion !== null ? religion[advancedSearchPreferences.religion as number] : 'Choose', onClick: () => setAdvancedSearchModalShowing('religion') }
+        { label: 'Gender', value: advancedSearchPreferences?.gender || 'Choose', onClick: () => setAdvancedSearchModalShowing('gender') },
+        { label: 'Age', value: `${advancedSearchPreferences?.age_range?.min} - ${advancedSearchPreferences?.age_range?.max} years old` || 'Choose', onClick: () => setAdvancedSearchModalShowing('age-range') },
+        { label: 'Country of Residence', value: advancedSearchPreferences?.country || 'Choose', onClick: () => setAdvancedSearchModalShowing('country') },
+        { label: 'Relationship Preference', value: advancedSearchPreferences?.relationship_preference !== null && advancedSearchPreferences?.relationship_preference !== undefined ? preference[advancedSearchPreferences.relationship_preference as number] : 'Choose', onClick: () => setAdvancedSearchModalShowing('relationship_preference') },
+        { label: 'Religion', value: advancedSearchPreferences?.religion !== null && advancedSearchPreferences?.religion !== undefined ? religion[advancedSearchPreferences.religion as number] : 'Choose', onClick: () => setAdvancedSearchModalShowing('religion') }
     ];
 
     const noSearchResults = (profiles: User[]): number => {

--- a/src/pages/dashboard/ProfileSettings.tsx
+++ b/src/pages/dashboard/ProfileSettings.tsx
@@ -26,9 +26,10 @@ interface ProfileSettingsProps {
     }
     prefetchUserData: () => void;
     userShouldRetakePhoto: boolean;
+    faceVerificationStatus?: 'pending_review' | 'approved' | 'rejected' | null;
 }
 
-const ProfileSettings: FC<ProfileSettingsProps> = ({ activePage, closePage, userSettings, prefetchUserData, userShouldRetakePhoto}) => {
+const ProfileSettings: FC<ProfileSettingsProps> = ({ activePage, closePage, userSettings, prefetchUserData, userShouldRetakePhoto, faceVerificationStatus}) => {
     const [profileSettings, setProfileSettings] = useState(userSettings);
     const [showBlockedContacts, setShowBlockedContacts] = useState(false);
     const [showModal, setShowModal] = useState<'hidden' | 'logout'>('hidden');
@@ -211,6 +212,13 @@ const ProfileSettings: FC<ProfileSettingsProps> = ({ activePage, closePage, user
                         <button onClick={() => setOpenModal(true)}>
                             <ProfileSettingsGroup title="Help and Support"/>
                         </button>
+                        {faceVerificationStatus && (
+                            <div className="px-[2.8rem] py-[1rem] text-[1.4rem] text-[#8A8A8E]">
+                                {faceVerificationStatus === 'pending_review' && 'Verification photo pending review'}
+                                {faceVerificationStatus === 'approved' && 'Verification photo approved ✅'}
+                                {faceVerificationStatus === 'rejected' && "Your verification photo didn't match the pose — please retake it"}
+                            </div>
+                        )}
                         {userShouldRetakePhoto && <button onClick={() => setOpenFaceVModal(true)}>
                             <ProfileSettingsGroup title="Take Verification Photo"/>
                         </button>}

--- a/src/pages/dashboard/UserProfile.tsx
+++ b/src/pages/dashboard/UserProfile.tsx
@@ -1,5 +1,7 @@
 import { motion } from 'framer-motion';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
+import { doc, onSnapshot } from 'firebase/firestore';
+import { db } from '@/firebase';
 import DashboardPageContainer from '../../components/dashboard/DashboardPageContainer';
 import ProfilePlan from '../../components/dashboard/ProfilePlan';
 import EditProfile from './EditProfile';
@@ -59,10 +61,29 @@ const UserProfile = () => {
         setUserFilters(data)
     }
 
+    const prevFaceVerificationStatusRef = useRef<'pending_review' | 'approved' | 'rejected' | null | undefined>(undefined);
+
     useEffect(() => {
-        fetchUserData().catch(err => console.log(err));
+        if (!auth?.uid) return;
+
+        const unsubscribe = onSnapshot(doc(db, "users", auth.uid), (snapshot) => {
+            if (!snapshot.exists()) return;
+            const data = snapshot.data() as User;
+            setUserData(data);
+            setCompleted(checkUserProfileCompletion(data));
+
+            const status = data.face_verification?.status;
+            const prevStatus = prevFaceVerificationStatusRef.current;
+            if (prevStatus !== undefined && prevStatus !== 'rejected' && status === 'rejected') {
+                toast.error("Your selfie didn't match the pose — please retake your verification photo");
+            }
+            prevFaceVerificationStatusRef.current = status;
+        }, (err) => console.log("Error fetching user data:", err));
+
         fetchUserFilters().catch(err => console.log(err));
-    }, []);
+
+        return () => unsubscribe();
+    }, [auth?.uid]);
 
     const refetchUserData = async () => { await fetchUserData() }
     const refetchUserFilters = async () => { await fetchUserFilters() }
@@ -134,7 +155,8 @@ const UserProfile = () => {
             <ProfileSettings
                 activePage={activePage == 'profile-settings'} closePage={() => setActivePage('user-profile')}
                 userSettings={{ incoming_messages: userData?.user_settings?.incoming_messages, public_search: userData?.user_settings?.public_search, online_status: userData?.user_settings?.online_status, read_receipts: userData?.user_settings?.read_receipts }}
-                prefetchUserData={refetchUserData} userShouldRetakePhoto={userData?.face_verification?.retake_photo as boolean} />
+                prefetchUserData={refetchUserData} userShouldRetakePhoto={userData?.face_verification?.retake_photo as boolean}
+                faceVerificationStatus={userData?.face_verification?.status} />
             <Preferences activePage={activePage == 'preferences'} closePage={() => setActivePage('user-profile')} onInterests={() => setActivePage('interests')} userData={userData} userFilters={userFilters} refetchUserData={refetchUserData} refetchUserFilters={refetchUserFilters} />
             <PreviewProfile activePage={activePage} activeSubPage={activeSubPage} closePage={() => { setActivePage('edit-profile'); setActiveSubPage(0) }} setActiveSubPage={setActiveSubPage} userData={userData} />
             <PreferredInterestsDesktop activePage={activePage == 'interests'} closePage={() => setActivePage('preferences')} onInterests={() => setActivePage('interests')} userFilters={userFilters} refetchUserFilters={refetchUserFilters} />

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -77,6 +77,11 @@ export type User = {
     retake_photo?: boolean | null;
     photo?: string | null;
     updated_at?: Timestamp | Date | null;
+    challenge_id?: string | null;
+    challenge_image_url?: string | null;
+    status?: 'pending_review' | 'approved' | 'rejected' | null;
+    reviewed_by?: string | null;
+    reviewed_at?: Timestamp | Date | null;
   }
   tour_guide?: {
     explore?: boolean;

--- a/src/types/verification.ts
+++ b/src/types/verification.ts
@@ -1,0 +1,9 @@
+import { Timestamp } from "firebase/firestore";
+
+export type VerificationChallenge = {
+  id?: string;
+  image_url: string;
+  label: string;
+  is_active: boolean;
+  created_at?: Timestamp | Date | null;
+};


### PR DESCRIPTION
## Summary
- Adds pose-based selfie verification: users match a random active challenge during onboarding and profile retakes, with challenge metadata stored on `face_verification`
- Adds admin routes (`/admin/verifications`, `/admin/challenges`) for reviewing pending submissions and managing challenge poses
- Fixes Explore white-screen for new accounts by returning safe defaults when advanced search prefs are missing and guarding against invalid `meet` values during profile fetch

## Test plan
- [x] `npm run build`
- [ ] Complete onboarding as a new user and confirm `/dashboard/explore` loads without a blank screen
- [ ] Submit a verification selfie and confirm it appears in the admin verification queue
- [ ] Approve/reject a submission and confirm profile settings status updates live
- [ ] Add/activate/deactivate challenge poses from `/admin/challenges`